### PR TITLE
Add extension metadata

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,8 @@
+name: Tekton Client
+description: Inject the Tekton client without worrying about the complexity related to handling dependencies.
+metadata:
+  keywords:
+    - tekton
+  categories:
+    - "miscellaneous"
+  status: "preview"


### PR DESCRIPTION
This is necessary to have the extension listed in the registry.quarkus.io properly